### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hasta_la_vista_money.yaml
+++ b/.github/workflows/hasta_la_vista_money.yaml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: hasta-la-vista-money
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/TurtleOld/hasta-la-vista-money/security/code-scanning/8](https://github.com/TurtleOld/hasta-la-vista-money/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Based on the current workflow, it primarily reads repository contents and does not perform any write operations. Therefore, we will set `contents: read` as the permission. This ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
