### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   create-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/TurtleOld/hasta-la-vista-money/security/code-scanning/7](https://github.com/TurtleOld/hasta-la-vista-money/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow to explicitly define the required permissions. Since the workflow involves creating a release, it needs `contents: write` permission. All other permissions will be omitted to minimize access. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
